### PR TITLE
Add option to save intermediate results of linear solvers

### DIFF
--- a/src/py/quantum_linsolve.py
+++ b/src/py/quantum_linsolve.py
@@ -133,23 +133,21 @@ def main(debug=False, save_intermediate_linear_solver_results=True):
     # solve
     result = solver(A, b)
 
-    # pickle the solution by appending it to a list of previous solutions
+    # pickle the solution and/or append it to a list of previous solutions
     if debug or save_intermediate_linear_solver_results:
         try:
-            if not os.path.exists(sol_info):
-                # initialize sol_info with the first result
-                with open(sol_info, "wb") as fb:
-                    pickle.dump([result], fb)
-            else:
-                # append the new result to sol_info
+            existing_data = []
+            if os.path.exists(sol_info):
+                # read existing data
                 with open(sol_info, "rb") as fb:
                     existing_data = pickle.load(fb)
-                if isinstance(existing_data, list):
-                    existing_data.append(result)
-                else:
-                    existing_data = [existing_data, result]
-                with open(sol_info, "wb") as fb:
-                    pickle.dump(existing_data, fb)
+                if not isinstance(existing_data, list):
+                    existing_data = [existing_data]
+            # append the new result
+            existing_data.append(result)
+            # write updated data
+            with open(sol_info, "wb") as fb:
+                pickle.dump(existing_data, fb)
         except Exception as err:
             print(f"An error occurred while saving intermediate linear solver results: {err}")
 

--- a/src/py/quantum_linsolve.py
+++ b/src/py/quantum_linsolve.py
@@ -112,8 +112,11 @@ def load_json_data(file_name: str) -> (spsp.csr_array, np.ndarray, np.ndarray): 
 
 def save_serializable_result(result, sol_info):
     """Pickle intermediate linear solver results."""
-    # check if the object is serializable
-    if not dill.pickles(result):
+    # check first if the object is serializable
+    try:
+        # attempt to pickle the object
+        pickle.dumps(result)
+    except (pickle.PicklingError, TypeError):
         print(f"Object {result.__class__.__name__} not serializable.")
         print(f"{sol_info} not created.")
         return
@@ -122,14 +125,14 @@ def save_serializable_result(result, sol_info):
         existing_data = []
         if os.path.exists(sol_info):
             with open(sol_info, "rb") as fb:
-                existing_data = dill.load(fb)
+                existing_data = pickle.load(fb)
                 if not isinstance(existing_data, list):
                     existing_data = [existing_data]
 
         # append the new result and save it back to the file
         existing_data.append(result)
         with open(sol_info, "wb") as fb:
-            dill.dump(existing_data, fb)
+            pickle.dump(existing_data, fb)
 
     except Exception as err:
         print(f"An error occurred while saving intermediate linear solver results: {err}")


### PR DESCRIPTION
Here is a small modification to the python part, allowing us to save intermediate results from linear solver.
See also https://github.com/QuantumApplicationLab/wntr-quantum/pull/24

## Note

The removal of the `sol_info.pckl` file is handled by the `QuantumEpanetSimulator` every time it is instantiated, so `os.path.exists(sol_info)` is always `False` whenever `quantum_linearsolve.py` is run for the first time.